### PR TITLE
Depend on illuminate/support 4.2 and fixed flysystem version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require": {
         "php": ">=5.5.9",
         "guzzlehttp/guzzle": "^6.2",
-        "league/flysystem": "~1.0",
-        "illuminate/support": "~5.1|~5.2|~5.3|~5.4|~5.5"
+        "league/flysystem": "1.0.41",
+        "illuminate/support": "~4.2|~5.1|~5.2|~5.3|~5.4|~5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.7|^6.0"


### PR DESCRIPTION
illuminate/support is only used for simple Collection operations, which are perfectly supported by v4.2.
Also, I had to set flysystem to a fixed version (latest v1) because otherwise composer told me that it requires PHP >=5.6 (the flysystem guys actually changed that dependency back and forth somewhere in time)