### PR TITLE
Downloading after upload is not working

### DIFF
--- a/src/Client/DropboxClient.php
+++ b/src/Client/DropboxClient.php
@@ -481,6 +481,7 @@ class DropboxClient
                 'body'    => !empty($this->content) ? $this->content : '',
             ]);
         } catch (HttpClientException $exception) {
+            $this->content = null;
             throw $this->determineException($exception);
         }
         $this->content = null;

--- a/src/Client/DropboxClient.php
+++ b/src/Client/DropboxClient.php
@@ -483,7 +483,7 @@ class DropboxClient
         } catch (HttpClientException $exception) {
             throw $this->determineException($exception);
         }
-
+        $this->content = null;
         return $response;
     }
 


### PR DESCRIPTION
Received the following error message from the Dropbox API:
"Error is call to API function "files/download": The request body is supposed to be empty, but isn't..."

I am clearing the content variable after the call is made to dropbox
