### PR TITLE
Include content type header even when POST body is empty...

### DIFF
--- a/src/Client/DropboxClient.php
+++ b/src/Client/DropboxClient.php
@@ -462,9 +462,10 @@ class DropboxClient
                 $this->request
             ),
         ];
-
-        if (!empty($this->content)) {
-            $headers['Content-Type'] = 'application/octet-stream';
+	if (!empty($this->content) || 
+	           $this->apiEndpoint == 'files/upload_session/finish') {
+            // The upload_session/finish API requires a Content-Type, always
+	    $headers['Content-Type'] = 'application/octet-stream';
         }
 
         return $headers;


### PR DESCRIPTION
for the /files/uploadSession/finish API call. This fixes uploads.